### PR TITLE
[FIX] Integer Division by zero on Windows build

### DIFF
--- a/sam.cpp
+++ b/sam.cpp
@@ -1953,6 +1953,7 @@ struct ggml_cgraph  * sam_build_fast_graph(
 }
 
 std::shared_ptr<sam_state> sam_load_model(const sam_params & params) {
+    ggml_time_init();
     const int64_t t_start_ms = ggml_time_ms();
 
     sam_state state;


### PR DESCRIPTION
Fixes a division by zero exception on Windows due to "timer_freq" not being initialized when ggml_time_ms() is called.

Not tested in other platforms because I don't have them 😓 