### PR TITLE
automatically downscale image when exceeds screen

### DIFF
--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -10,6 +10,7 @@
 #define SDL_DISABLE_ARM_NEON_H 1
 #include <SDL.h>
 #include <SDL_opengl.h>
+#include <cmath>
 
 #if defined(_MSC_VER)
 #pragma warning(disable: 4244 4267) // possible loss of data
@@ -97,7 +98,7 @@ static int resize_img_if_exceed_screen(sam_image_u8 &img, SDL_Window* window) {
       // downscale
       float scale_y = (float)img.ny/screen_height;
       float scale_x = (float)img.nx/screen_width;
-      uint8_t scale = std::max(scale_x, scale_y);
+      uint8_t scale = std::ceil(std::max(scale_x, scale_y));
 
       img = resize_image_data(img, scale);
     }

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -15,6 +15,42 @@
 #pragma warning(disable: 4244 4267) // possible loss of data
 #endif
 
+// resize image with nearest-neighbor interpolation
+static sam_image_u8 resize_image_data(sam_image_u8 &img , uint8_t scale) {
+  if (scale == 1) {
+    return img;
+  }
+  sam_image_u8 new_img;
+
+  int width = img.nx;
+  int height = img.ny;
+
+  int new_width = img.nx / scale;
+  int new_height = img.ny / scale;
+
+  new_img.nx = new_width;
+  new_img.ny = new_height;
+  new_img.data.resize(new_img.nx*new_img.ny*3);
+  fprintf(stderr, "%s: resize image from (%d x %d) to (%d x %d)\n", __func__, img.nx, img.ny, new_img.nx, new_img.ny);
+
+  // the number of channels is always 3 from load_image_from_file
+  for (int y = 0; y < new_height; ++y) {
+    for (int x = 0; x < new_width; ++x) {
+      int src_x = x * scale;
+      int src_y = y * scale;
+
+      int src_index = (src_y * width + src_x) * 3;
+      int dest_index = (y * new_width + x) * 3;
+
+      for (int c = 0; c < 3; ++c) {
+        new_img.data[dest_index + c] = img.data[src_index+c];
+      }
+    }
+  }
+
+  return new_img;
+}
+
 static bool load_image_from_file(const std::string & fname, sam_image_u8 & img) {
     int nx, ny, nc;
     auto data = stbi_load(fname.c_str(), &nx, &ny, &nc, 3);
@@ -44,6 +80,7 @@ static void print_usage(int argc, char ** argv, const sam_params & params) {
     fprintf(stderr, "  -h, --help            show this help message and exit\n");
     fprintf(stderr, "  -s SEED, --seed SEED  RNG seed (default: -1)\n");
     fprintf(stderr, "  -t N, --threads N     number of threads to use during computation (default: %d)\n", params.n_threads);
+    fprintf(stderr, "  -f N, --factor N      scale factor for the image (default: 1)\n");
     fprintf(stderr, "  -m FNAME, --model FNAME\n");
     fprintf(stderr, "                        model path (default: %s)\n", params.model.c_str());
     fprintf(stderr, "  -i FNAME, --inp FNAME\n");
@@ -67,6 +104,8 @@ static bool params_parse(int argc, char ** argv, sam_params & params) {
             params.fname_inp = argv[++i];
         } else if (arg == "-o" || arg == "--out") {
             params.fname_out = argv[++i];
+        } else if (arg == "-f" || arg == "--factor") {
+            params.factor = std::stoi(argv[++i]);
         } else if (arg == "-h" || arg == "--help") {
             print_usage(argc, argv, params);
             exit(0);
@@ -141,7 +180,9 @@ int main_loop(sam_image_u8 img, const sam_params & params, sam_state & state) {
 
     const char * title = "SAM.cpp";
     SDL_WindowFlags window_flags = (SDL_WindowFlags)(SDL_WINDOW_OPENGL | SDL_WINDOW_ALLOW_HIGHDPI);
-    SDL_Window * window = SDL_CreateWindow(title, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, img.nx, img.ny, window_flags);
+    sam_image_u8 resized_img = resize_image_data(img, params.factor);
+
+    SDL_Window * window = SDL_CreateWindow(title, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, resized_img.nx, resized_img.ny, window_flags);
     if (!window) {
         fprintf(stderr, "Error: %s\n", SDL_GetError());
         return -1;
@@ -153,6 +194,7 @@ int main_loop(sam_image_u8 img, const sam_params & params, sam_state & state) {
     SDL_GL_SetSwapInterval(1); // Enable vsync
 
     GLuint tex = createGLTexture(img, GL_RGB);
+    GLuint resized_tex = createGLTexture(resized_img, GL_RGB);
 
     ImGui_Init(window, gl_context);
     ImGui::GetIO().IniFilename = nullptr;
@@ -163,6 +205,7 @@ int main_loop(sam_image_u8 img, const sam_params & params, sam_state & state) {
     ImGui_EndFrame(window);
 
     bool done = false;
+    // x and y at original image
     float x = 0.f, y = 0.f;
     std::vector<sam_image_u8> masks;
     std::vector<GLuint> maskTextures;
@@ -183,13 +226,13 @@ int main_loop(sam_image_u8 img, const sam_params & params, sam_state & state) {
             if (event.type == SDL_MOUSEBUTTONDOWN) {
                 if (event.button.button == SDL_BUTTON_LEFT) {
                     computeMasks = true;
-                    x = event.button.x;
-                    y = event.button.y;
+                    x = event.button.x * params.factor;
+                    y = event.button.y * params.factor;
                 }
             }
             if (segmentOnHover && event.type == SDL_MOUSEMOTION) {
-                x = event.motion.x;
-                y = event.motion.y;
+                x = event.motion.x * params.factor;
+                y = event.motion.y * params.factor;
             }
             if (event.type == SDL_DROPFILE) {
                 sam_image_u8 new_img;
@@ -203,8 +246,12 @@ int main_loop(sam_image_u8 img, const sam_params & params, sam_state & state) {
                     }
                     printf("t_compute_img_ms = %d ms\n", state.t_compute_img_ms);
                     img = std::move(new_img);
+                    resized_img = resize_image_data(img, params.factor);
+
                     tex = createGLTexture(img, GL_RGB);
-                    SDL_SetWindowSize(window, img.nx, img.ny);
+                    resized_tex = createGLTexture(resized_img, GL_RGB);
+
+                    SDL_SetWindowSize(window, resized_img.nx, resized_img.ny);
                     SDL_SetWindowTitle(window, title);
                     computeMasks = true;
                 }
@@ -221,6 +268,7 @@ int main_loop(sam_image_u8 img, const sam_params & params, sam_state & state) {
                 glDeleteTextures(maskTextures.size(), maskTextures.data());
                 maskTextures.clear();
             }
+
             for (auto& mask : masks) {
                 sam_image_u8 mask_rgb = { mask.nx, mask.ny, };
                 mask_rgb.data.resize(3*mask.nx*mask.ny);
@@ -241,14 +289,14 @@ int main_loop(sam_image_u8 img, const sam_params & params, sam_state & state) {
         ImGui::Begin(title, NULL, ImGuiWindowFlags_NoTitleBar|ImGuiWindowFlags_NoResize|ImGuiWindowFlags_NoMove|ImGuiWindowFlags_NoScrollbar|ImGuiWindowFlags_NoScrollWithMouse);
 
         ImDrawList* draw_list = ImGui::GetWindowDrawList();
-        draw_list->AddImage((void*)(intptr_t)tex, ImVec2(0,0), ImVec2(img.nx, img.ny));
+        draw_list->AddImage((void*)(intptr_t)resized_tex, ImVec2(0,0), ImVec2(resized_img.nx, resized_img.ny));
 
         ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 0, 0, 255));
         ImGui::Checkbox("Segment on hover", &segmentOnHover);
         ImGui::Checkbox("Output multiple masks", &outputMultipleMasks);
         ImGui::PopStyleColor();
 
-        draw_list->AddCircleFilled(ImVec2(x, y), 5, IM_COL32(255, 0, 0, 255));
+        draw_list->AddCircleFilled(ImVec2(x / params.factor, y / params.factor), 5, IM_COL32(255, 0, 0, 255));
 
         draw_list->AddCallback(enable_blending, {});
 
@@ -257,11 +305,11 @@ int main_loop(sam_image_u8 img, const sam_params & params, sam_state & state) {
                 const int r = i == 0 ? 255 : 0;
                 const int g = i == 1 ? 255 : 0;
                 const int b = i == 2 ? 255 : 0;
-                draw_list->AddImage((void*)(intptr_t)maskTextures[i], ImVec2(0,0), ImVec2(img.nx, img.ny), ImVec2(0,0), ImVec2(1,1), IM_COL32(r, g, b, 172));
+                draw_list->AddImage((void*)(intptr_t)maskTextures[i], ImVec2(0,0), ImVec2(resized_img.nx, resized_img.ny), ImVec2(0,0), ImVec2(1,1), IM_COL32(r, g, b, 172));
             }
         }
         else if (!maskTextures.empty()) {
-            draw_list->AddImage((void*)(intptr_t)maskTextures[0], ImVec2(0,0), ImVec2(img.nx, img.ny), ImVec2(0,0), ImVec2(1,1), IM_COL32(0, 0, 255, 128));
+            draw_list->AddImage((void*)(intptr_t)maskTextures[0], ImVec2(0,0), ImVec2(resized_img.nx, resized_img.ny), ImVec2(0,0), ImVec2(1,1), IM_COL32(0, 0, 255, 128));
         }
 
         draw_list->AddCallback(disable_blending, {});

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -105,7 +105,7 @@ static bool params_parse(int argc, char ** argv, sam_params & params) {
         } else if (arg == "-o" || arg == "--out") {
             params.fname_out = argv[++i];
         } else if (arg == "-f" || arg == "--factor") {
-            params.factor = std::stoi(argv[++i]);
+            params.factor = std::max(1, std::stoi(argv[++i]));
         } else if (arg == "-h" || arg == "--help") {
             print_usage(argc, argv, params);
             exit(0);

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -15,40 +15,94 @@
 #pragma warning(disable: 4244 4267) // possible loss of data
 #endif
 
+/**
+ * Get the size of screen where the SDL window runs in.
+ *
+ * SDL_Window* window could be NULL, which means we get the screen size of the default 0-index display.
+ * If window is not NULL, the we need to get the screen size of the display where the window runs in.
+ *
+ */
+static bool get_screen_size(SDL_DisplayMode &dm, SDL_Window* window) {
+  int displayIndex = 0;
+  if (window != NULL) {
+    displayIndex = SDL_GetWindowDisplayIndex(window);
+  }
+  if (displayIndex < 0) {
+    return false;
+  }
+  if (SDL_GetCurrentDisplayMode(displayIndex, &dm) != 0) {
+    return false;
+  }
+
+  fprintf(stderr, "%s: screen size (%d x %d) \n", __func__, dm.w, dm.h);
+  return true;
+}
+
 // resize image with nearest-neighbor interpolation
 static sam_image_u8 resize_image_data(sam_image_u8 &img , uint8_t scale) {
-  if (scale == 1) {
-    return img;
-  }
   sam_image_u8 new_img;
 
   int width = img.nx;
   int height = img.ny;
 
-  int new_width = img.nx / scale;
+  int new_width = img.ny / scale;
   int new_height = img.ny / scale;
 
   new_img.nx = new_width;
   new_img.ny = new_height;
   new_img.data.resize(new_img.nx*new_img.ny*3);
+
+  fprintf(stderr, "%s: scale: %d\n", __func__, scale);
   fprintf(stderr, "%s: resize image from (%d x %d) to (%d x %d)\n", __func__, img.nx, img.ny, new_img.nx, new_img.ny);
 
-  // the number of channels is always 3 from load_image_from_file
   for (int y = 0; y < new_height; ++y) {
-    for (int x = 0; x < new_width; ++x) {
-      int src_x = x * scale;
-      int src_y = y * scale;
+      for (int x = 0; x < new_width; ++x) {
+          int src_x = x * scale;
+          int src_y = y * scale;
 
-      int src_index = (src_y * width + src_x) * 3;
-      int dest_index = (y * new_width + x) * 3;
+          int src_index = (src_y * width + src_x) * 3;
+          int dest_index = (y * new_width + x) * 3;
 
-      for (int c = 0; c < 3; ++c) {
-        new_img.data[dest_index + c] = img.data[src_index+c];
+          for (int c = 0; c < 3; ++c) {
+              new_img.data[dest_index + c] = img.data[src_index + c];
+          }
       }
-    }
   }
 
+
   return new_img;
+}
+
+static int resize_img_if_exceed_screen(sam_image_u8 &img, SDL_Window* window) {
+    // get the screen size
+    SDL_DisplayMode dm = {};
+    if (!get_screen_size(dm, window)) {
+      fprintf(stderr, "%s: failed to get screen size of the display.\n", __func__);
+      return -1;
+    }
+
+    int screen_width = dm.w;
+    int screen_height= dm.h;
+
+    fprintf(stderr, "%s: img size (%d x %d) \n", __func__,img.nx,img.ny);
+    fprintf(stderr, "%s: screen size (%d x %d) \n", __func__,dm.w,dm.h);
+
+    if (screen_height == 0 || screen_width == 0) {
+      // This means the window is running in other display.
+      return -1;
+    }
+
+    if (img.ny > screen_height || img.nx > screen_width) {
+      fprintf(stderr, "%s: img size (%d x %d) exceeds screen size (%d x %d) \n", __func__,img.nx,img.ny,screen_width,screen_height);
+      // downscale
+      float scale_y = (float)img.ny/screen_height;
+      float scale_x = (float)img.nx/screen_width;
+      uint8_t scale = std::max(scale_x, scale_y);
+
+      img = resize_image_data(img, scale);
+    }
+
+    return 0;
 }
 
 static bool load_image_from_file(const std::string & fname, sam_image_u8 & img) {
@@ -80,7 +134,6 @@ static void print_usage(int argc, char ** argv, const sam_params & params) {
     fprintf(stderr, "  -h, --help            show this help message and exit\n");
     fprintf(stderr, "  -s SEED, --seed SEED  RNG seed (default: -1)\n");
     fprintf(stderr, "  -t N, --threads N     number of threads to use during computation (default: %d)\n", params.n_threads);
-    fprintf(stderr, "  -f N, --factor N      scale factor for the image (default: 1)\n");
     fprintf(stderr, "  -m FNAME, --model FNAME\n");
     fprintf(stderr, "                        model path (default: %s)\n", params.model.c_str());
     fprintf(stderr, "  -i FNAME, --inp FNAME\n");
@@ -104,8 +157,6 @@ static bool params_parse(int argc, char ** argv, sam_params & params) {
             params.fname_inp = argv[++i];
         } else if (arg == "-o" || arg == "--out") {
             params.fname_out = argv[++i];
-        } else if (arg == "-f" || arg == "--factor") {
-            params.factor = std::max(1, std::stoi(argv[++i]));
         } else if (arg == "-h" || arg == "--help") {
             print_usage(argc, argv, params);
             exit(0);
@@ -171,18 +222,13 @@ void disable_blending(const ImDrawList*, const ImDrawCmd*) {
 }
 
 int main_loop(sam_image_u8 img, const sam_params & params, sam_state & state) {
-    if (SDL_Init(SDL_INIT_VIDEO) != 0) {
-        fprintf(stderr, "Error: %s\n", SDL_GetError());
-        return -1;
-    }
-
     ImGui_PreInit();
 
     const char * title = "SAM.cpp";
     SDL_WindowFlags window_flags = (SDL_WindowFlags)(SDL_WINDOW_OPENGL | SDL_WINDOW_ALLOW_HIGHDPI);
-    sam_image_u8 resized_img = resize_image_data(img, params.factor);
 
-    SDL_Window * window = SDL_CreateWindow(title, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, resized_img.nx, resized_img.ny, window_flags);
+    SDL_Window * window = SDL_CreateWindow(title, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, img.nx, img.ny, window_flags);
+
     if (!window) {
         fprintf(stderr, "Error: %s\n", SDL_GetError());
         return -1;
@@ -194,7 +240,6 @@ int main_loop(sam_image_u8 img, const sam_params & params, sam_state & state) {
     SDL_GL_SetSwapInterval(1); // Enable vsync
 
     GLuint tex = createGLTexture(img, GL_RGB);
-    GLuint resized_tex = createGLTexture(resized_img, GL_RGB);
 
     ImGui_Init(window, gl_context);
     ImGui::GetIO().IniFilename = nullptr;
@@ -226,13 +271,13 @@ int main_loop(sam_image_u8 img, const sam_params & params, sam_state & state) {
             if (event.type == SDL_MOUSEBUTTONDOWN) {
                 if (event.button.button == SDL_BUTTON_LEFT) {
                     computeMasks = true;
-                    x = event.button.x * params.factor;
-                    y = event.button.y * params.factor;
+                    x = event.button.x;
+                    y = event.button.y;
                 }
             }
             if (segmentOnHover && event.type == SDL_MOUSEMOTION) {
-                x = event.motion.x * params.factor;
-                y = event.motion.y * params.factor;
+                x = event.motion.x;
+                y = event.motion.y;
             }
             if (event.type == SDL_DROPFILE) {
                 sam_image_u8 new_img;
@@ -246,12 +291,12 @@ int main_loop(sam_image_u8 img, const sam_params & params, sam_state & state) {
                     }
                     printf("t_compute_img_ms = %d ms\n", state.t_compute_img_ms);
                     img = std::move(new_img);
-                    resized_img = resize_image_data(img, params.factor);
 
+                    // resize img when exceeds screen
+                    resize_img_if_exceed_screen(img, window);
                     tex = createGLTexture(img, GL_RGB);
-                    resized_tex = createGLTexture(resized_img, GL_RGB);
 
-                    SDL_SetWindowSize(window, resized_img.nx, resized_img.ny);
+                    SDL_SetWindowSize(window, img.nx, img.ny);
                     SDL_SetWindowTitle(window, title);
                     computeMasks = true;
                 }
@@ -289,14 +334,14 @@ int main_loop(sam_image_u8 img, const sam_params & params, sam_state & state) {
         ImGui::Begin(title, NULL, ImGuiWindowFlags_NoTitleBar|ImGuiWindowFlags_NoResize|ImGuiWindowFlags_NoMove|ImGuiWindowFlags_NoScrollbar|ImGuiWindowFlags_NoScrollWithMouse);
 
         ImDrawList* draw_list = ImGui::GetWindowDrawList();
-        draw_list->AddImage((void*)(intptr_t)resized_tex, ImVec2(0,0), ImVec2(resized_img.nx, resized_img.ny));
+        draw_list->AddImage((void*)(intptr_t)tex, ImVec2(0,0), ImVec2(img.nx, img.ny));
 
         ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 0, 0, 255));
         ImGui::Checkbox("Segment on hover", &segmentOnHover);
         ImGui::Checkbox("Output multiple masks", &outputMultipleMasks);
         ImGui::PopStyleColor();
 
-        draw_list->AddCircleFilled(ImVec2(x / params.factor, y / params.factor), 5, IM_COL32(255, 0, 0, 255));
+        draw_list->AddCircleFilled(ImVec2(x, y), 5, IM_COL32(255, 0, 0, 255));
 
         draw_list->AddCallback(enable_blending, {});
 
@@ -305,11 +350,11 @@ int main_loop(sam_image_u8 img, const sam_params & params, sam_state & state) {
                 const int r = i == 0 ? 255 : 0;
                 const int g = i == 1 ? 255 : 0;
                 const int b = i == 2 ? 255 : 0;
-                draw_list->AddImage((void*)(intptr_t)maskTextures[i], ImVec2(0,0), ImVec2(resized_img.nx, resized_img.ny), ImVec2(0,0), ImVec2(1,1), IM_COL32(r, g, b, 172));
+                draw_list->AddImage((void*)(intptr_t)maskTextures[i], ImVec2(0,0), ImVec2(img.nx, img.ny), ImVec2(0,0), ImVec2(1,1), IM_COL32(r, g, b, 172));
             }
         }
         else if (!maskTextures.empty()) {
-            draw_list->AddImage((void*)(intptr_t)maskTextures[0], ImVec2(0,0), ImVec2(resized_img.nx, resized_img.ny), ImVec2(0,0), ImVec2(1,1), IM_COL32(0, 0, 255, 128));
+            draw_list->AddImage((void*)(intptr_t)maskTextures[0], ImVec2(0,0), ImVec2(img.nx,img.ny), ImVec2(0,0), ImVec2(1,1), IM_COL32(0, 0, 255, 128));
         }
 
         draw_list->AddCallback(disable_blending, {});
@@ -343,6 +388,15 @@ int main(int argc, char ** argv) {
         return 1;
     }
     fprintf(stderr, "%s: loaded image '%s' (%d x %d)\n", __func__, params.fname_inp.c_str(), img0.nx, img0.ny);
+
+    // init SDL video subsystem to get the screen size
+    if (SDL_Init(SDL_INIT_VIDEO) != 0) {
+        fprintf(stderr, "Error: %s\n", SDL_GetError());
+        return -1;
+    }
+
+    // resize img when exceeds the screen
+    resize_img_if_exceed_screen(img0, NULL);
 
     std::shared_ptr<sam_state> state = sam_load_model(params);
     if (!state) {

--- a/sam.h
+++ b/sam.h
@@ -22,6 +22,7 @@ struct sam_image_u8 {
 struct sam_params {
     int32_t seed      = -1; // RNG seed
     int32_t n_threads = std::min(4, (int32_t) std::thread::hardware_concurrency());
+    uint8_t factor = 1;
 
     std::string model     = "../checkpoints/ggml-model-f16-b.bin"; // model path
     std::string fname_inp = "../img.jpg";

--- a/sam.h
+++ b/sam.h
@@ -22,7 +22,6 @@ struct sam_image_u8 {
 struct sam_params {
     int32_t seed      = -1; // RNG seed
     int32_t n_threads = std::min(4, (int32_t) std::thread::hardware_concurrency());
-    uint8_t factor = 1;
 
     std::string model     = "../checkpoints/ggml-model-f16-b.bin"; // model path
     std::string fname_inp = "../img.jpg";


### PR DESCRIPTION
I found that if the image resolution is really large then the SDL window probably exceed the size of the screen. So this PR aims to resolve this issue.

I wonder if it's okay to add a scale parameter to scale down the window size by downsizing the image displayed in the window. After testing the workaround on my machine, I think it has resolved the window size issue when the image resolution is larger than the screen's. 

The resizing algorithm I used is simple, which is the nearest neighbor interpolation.