### PR TITLE
examples: Loading 4 channel images fix + readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,14 @@ cd sam.cpp
 Note: you need to download the model checkpoint below (`sam_vit_b_01ec64.pth`) first from [here](https://dl.fbaipublicfiles.com/segment_anything/sam_vit_b_01ec64.pth) and place it in the `checkpoints` folder
 
 ```bash
-# Convert PTH model to ggml. Requires python3, torch and numpy
-python convert-pth-to-ggml.py checkpoints/sam_vit_b_01ec64.pth . 1
+# Download PTH model and place it under checkpoints
+mkdir checkpoints
+wget -P checkpoints https://dl.fbaipublicfiles.com/segment_anything/sam_vit_b_01ec64.pth
 
-# You need CMake and SDL2
-SDL2 - Used for GUI windows & input [libsdl](https://www.libsdl.org)
+# Convert PTH model to ggml. Requires python3, torch and numpy
+python convert-pth-to-ggml.py checkpoints/sam_vit_b_01ec64.pth checkpoints 1
+
+# You need CMake and SDL2 - Used for GUI windows & input [libsdl](https://www.libsdl.org)
 
 [Ubuntu]
 $ sudo apt install libsdl2-dev

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -113,8 +113,7 @@ static bool load_image_from_file(const std::string & fname, sam_image_u8 & img) 
         return false;
     }
     if (nc != 3) {
-        fprintf(stderr, "%s: '%s' has %d channels (expected 3)\n", __func__, fname.c_str(), nc);
-        return false;
+        fprintf(stdout, "%s: converted '%s' %d channels to 3\n", __func__, fname.c_str(), nc);
     }
 
     img.nx = nx;


### PR DESCRIPTION
The nc is returned as 4, but the library already has handled the conversion.